### PR TITLE
Implement Phase 2.3: Format Validators

### DIFF
--- a/.claude/backlog.md
+++ b/.claude/backlog.md
@@ -37,9 +37,9 @@
 - [ ] `FloatValidator` - Floating point validation with precision
 
 ### 2.3 Format Validators
-- [ ] `PhoneValidator` - International phone number formats
-- [ ] `IbanValidator` - International Bank Account Number validation
-- [ ] `UuidValidator` - UUID format validation (v4)
+- [x] `PhoneValidator` - International phone number formats
+- [x] `IbanValidator` - International Bank Account Number validation
+- [x] `UuidValidator` - UUID format validation (v4)
 
 ### 2.4 Convenience Methods
 - [ ] Add `isEmail()`, `isUrl()`, `isPhone()` methods to main Validator class

--- a/src/Validators/IbanValidator.php
+++ b/src/Validators/IbanValidator.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingyValidator\Validators;
+
+use ThingyValidator\AbstractValidator;
+use ThingyValidator\ValidationContext;
+use ThingyValidator\ValidationResult;
+
+/**
+ * Validates International Bank Account Numbers (IBAN)
+ *
+ * Validates IBAN format according to ISO 13616 standard using:
+ * - Country code validation (2 letters)
+ * - Check digit validation (2 digits)
+ * - Country-specific length validation
+ * - MOD-97 checksum algorithm
+ *
+ * Supports all SEPA countries and major international IBAN formats.
+ *
+ * Usage:
+ * ```php
+ * $validator = new IbanValidator();
+ * $result = $validator->validate('LT601010012345678901');  // Valid (Lithuania)
+ * $result = $validator->validate('GB82WEST12345698765432'); // Valid (UK)
+ * $result = $validator->validate('DE89370400440532013000'); // Valid (Germany)
+ * $result = $validator->validate('INVALID');               // Invalid
+ * ```
+ *
+ * @package ThingyValidator\Validators
+ */
+class IbanValidator extends AbstractValidator
+{
+    /**
+     * IBAN lengths by country code (ISO 13616)
+     *
+     * @var array<string, int>
+     */
+    private const IBAN_LENGTHS = [
+        'AD' => 24, 'AE' => 23, 'AL' => 28, 'AT' => 20, 'AZ' => 28,
+        'BA' => 20, 'BE' => 16, 'BG' => 22, 'BH' => 22, 'BR' => 29,
+        'BY' => 28, 'CH' => 21, 'CR' => 22, 'CY' => 28, 'CZ' => 24,
+        'DE' => 22, 'DK' => 18, 'DO' => 28, 'EE' => 20, 'EG' => 29,
+        'ES' => 24, 'FI' => 18, 'FO' => 18, 'FR' => 27, 'GB' => 22,
+        'GE' => 22, 'GI' => 23, 'GL' => 18, 'GR' => 27, 'GT' => 28,
+        'HR' => 21, 'HU' => 28, 'IE' => 22, 'IL' => 23, 'IS' => 26,
+        'IT' => 27, 'JO' => 30, 'KW' => 30, 'KZ' => 20, 'LB' => 28,
+        'LC' => 32, 'LI' => 21, 'LT' => 20, 'LU' => 20, 'LV' => 21,
+        'MC' => 27, 'MD' => 24, 'ME' => 22, 'MK' => 19, 'MR' => 27,
+        'MT' => 31, 'MU' => 30, 'NL' => 18, 'NO' => 15, 'PK' => 24,
+        'PL' => 28, 'PS' => 29, 'PT' => 25, 'QA' => 29, 'RO' => 24,
+        'RS' => 22, 'SA' => 24, 'SE' => 24, 'SI' => 19, 'SK' => 24,
+        'SM' => 27, 'TN' => 24, 'TR' => 26, 'UA' => 29, 'VA' => 22,
+        'VG' => 24, 'XK' => 20,
+    ];
+
+    /**
+     * Create a new IBAN validator
+     */
+    public function __construct()
+    {
+        parent::__construct('iban');
+        $this->errorMessage = 'Invalid IBAN format';
+        $this->successMessage = 'Valid IBAN';
+    }
+
+    /**
+     * Perform IBAN validation
+     *
+     * @param mixed $value The value to validate
+     * @param ValidationContext|null $context Optional validation context
+     * @return ValidationResult The validation result
+     */
+    protected function doValidate(mixed $value, ?ValidationContext $context): ValidationResult
+    {
+        // Must be a string
+        if (!is_string($value)) {
+            return $this->failure(
+                sprintf('IBAN must be a string, %s given', gettype($value)),
+                ['type' => gettype($value)]
+            );
+        }
+
+        // Remove spaces and convert to uppercase
+        $iban = strtoupper(str_replace(' ', '', trim($value)));
+
+        // Cannot be empty
+        if ($iban === '') {
+            return $this->failure(
+                'IBAN cannot be empty',
+                ['value' => $value]
+            );
+        }
+
+        // Must be alphanumeric
+        if (!ctype_alnum($iban)) {
+            return $this->failure(
+                sprintf('IBAN "%s" contains invalid characters', $value),
+                ['value' => $value, 'normalized' => $iban]
+            );
+        }
+
+        // Must be at least 15 characters (shortest IBAN is NO - 15 chars)
+        if (strlen($iban) < 15) {
+            return $this->failure(
+                sprintf('IBAN "%s" is too short (minimum 15 characters)', $value),
+                ['value' => $value, 'length' => strlen($iban)]
+            );
+        }
+
+        // Extract country code (first 2 letters)
+        $countryCode = substr($iban, 0, 2);
+        if (!ctype_alpha($countryCode)) {
+            return $this->failure(
+                sprintf('IBAN "%s" has invalid country code "%s"', $value, $countryCode),
+                ['value' => $value, 'country_code' => $countryCode]
+            );
+        }
+
+        // Extract check digits (positions 2-3, must be digits)
+        $checkDigits = substr($iban, 2, 2);
+        if (!ctype_digit($checkDigits)) {
+            return $this->failure(
+                sprintf('IBAN "%s" has invalid check digits "%s"', $value, $checkDigits),
+                ['value' => $value, 'check_digits' => $checkDigits]
+            );
+        }
+
+        // Validate country-specific length
+        if (!isset(self::IBAN_LENGTHS[$countryCode])) {
+            return $this->failure(
+                sprintf('IBAN country code "%s" is not supported', $countryCode),
+                ['value' => $value, 'country_code' => $countryCode]
+            );
+        }
+
+        $expectedLength = self::IBAN_LENGTHS[$countryCode];
+        if (strlen($iban) !== $expectedLength) {
+            return $this->failure(
+                sprintf(
+                    'IBAN "%s" has invalid length for country %s (expected %d, got %d)',
+                    $value,
+                    $countryCode,
+                    $expectedLength,
+                    strlen($iban)
+                ),
+                [
+                    'value' => $value,
+                    'country_code' => $countryCode,
+                    'expected_length' => $expectedLength,
+                    'actual_length' => strlen($iban),
+                    'constraint' => 'length'
+                ]
+            );
+        }
+
+        // Validate checksum using MOD-97 algorithm
+        if (!$this->validateChecksum($iban)) {
+            return $this->failure(
+                sprintf('IBAN "%s" has invalid checksum', $value),
+                [
+                    'value' => $value,
+                    'country_code' => $countryCode,
+                    'check_digits' => $checkDigits,
+                    'constraint' => 'checksum'
+                ]
+            );
+        }
+
+        // Success
+        return $this->success(
+            sprintf('IBAN "%s" is valid', $value),
+            [
+                'value' => $value,
+                'normalized' => $iban,
+                'country_code' => $countryCode,
+                'check_digits' => $checkDigits,
+                'length' => strlen($iban)
+            ]
+        );
+    }
+
+    /**
+     * Validate IBAN checksum using MOD-97 algorithm
+     *
+     * @param string $iban The IBAN to validate (already normalized)
+     * @return bool True if checksum is valid
+     */
+    private function validateChecksum(string $iban): bool
+    {
+        // Move first 4 characters to the end
+        $rearranged = substr($iban, 4) . substr($iban, 0, 4);
+
+        // Replace letters with numbers (A=10, B=11, ..., Z=35)
+        $numeric = '';
+        for ($i = 0; $i < strlen($rearranged); $i++) {
+            $char = $rearranged[$i];
+            if (ctype_alpha($char)) {
+                // A=10, B=11, etc.
+                $numeric .= (string) (ord($char) - ord('A') + 10);
+            } else {
+                $numeric .= $char;
+            }
+        }
+
+        // Perform MOD-97 calculation
+        // For large numbers, we need to process in chunks
+        $remainder = 0;
+        $numericLength = strlen($numeric);
+
+        for ($i = 0; $i < $numericLength; $i++) {
+            $remainder = ($remainder * 10 + (int) $numeric[$i]) % 97;
+        }
+
+        // Valid IBAN should have remainder of 1
+        return $remainder === 1;
+    }
+}

--- a/src/Validators/PhoneValidator.php
+++ b/src/Validators/PhoneValidator.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingyValidator\Validators;
+
+use ThingyValidator\AbstractValidator;
+use ThingyValidator\ValidationContext;
+use ThingyValidator\ValidationResult;
+
+/**
+ * Validates international phone numbers
+ *
+ * Validates phone numbers in E.164 format and common international formats.
+ * Supports optional country code, various separators, and basic format checking.
+ *
+ * Accepted formats:
+ * - E.164: +1234567890
+ * - With spaces: +1 234 567 890
+ * - With dashes: +1-234-567-890
+ * - With parentheses: +1 (234) 567-890
+ * - Without plus: 1234567890
+ * - Local format: (234) 567-890
+ *
+ * Usage:
+ * ```php
+ * $validator = new PhoneValidator();
+ * $result = $validator->validate('+37061234567');    // Valid (E.164)
+ * $result = $validator->validate('+1 (555) 123-4567'); // Valid
+ * $result = $validator->validate('555-1234');         // Valid (local)
+ * $result = $validator->validate('abc');              // Invalid
+ * ```
+ *
+ * @package ThingyValidator\Validators
+ */
+class PhoneValidator extends AbstractValidator
+{
+    /**
+     * Minimum phone number length (after removing non-digits)
+     */
+    private const MIN_LENGTH = 7;
+
+    /**
+     * Maximum phone number length (after removing non-digits)
+     */
+    private const MAX_LENGTH = 15;
+
+    /**
+     * Create a new phone validator
+     */
+    public function __construct()
+    {
+        parent::__construct('phone');
+        $this->errorMessage = 'Invalid phone number format';
+        $this->successMessage = 'Valid phone number';
+    }
+
+    /**
+     * Perform phone number validation
+     *
+     * @param mixed $value The value to validate
+     * @param ValidationContext|null $context Optional validation context
+     * @return ValidationResult The validation result
+     */
+    protected function doValidate(mixed $value, ?ValidationContext $context): ValidationResult
+    {
+        // Must be a string
+        if (!is_string($value)) {
+            return $this->failure(
+                sprintf('Phone number must be a string, %s given', gettype($value)),
+                ['type' => gettype($value)]
+            );
+        }
+
+        // Cannot be empty
+        $value = trim($value);
+        if ($value === '') {
+            return $this->failure(
+                'Phone number cannot be empty',
+                ['value' => $value]
+            );
+        }
+
+        // Extract only digits and plus sign for validation
+        $digitsOnly = preg_replace('/[^0-9+]/', '', $value);
+
+        // Check if there's at least one digit
+        if (!preg_match('/\d/', $digitsOnly)) {
+            return $this->failure(
+                sprintf('Phone number "%s" contains no digits', $value),
+                ['value' => $value, 'extracted' => $digitsOnly]
+            );
+        }
+
+        // Plus sign can only appear at the beginning
+        $plusCount = substr_count($digitsOnly, '+');
+        if ($plusCount > 1 || ($plusCount === 1 && $digitsOnly[0] !== '+')) {
+            return $this->failure(
+                sprintf('Phone number "%s" has invalid plus sign placement', $value),
+                ['value' => $value, 'extracted' => $digitsOnly]
+            );
+        }
+
+        // Remove plus for length check
+        $digitsForLength = str_replace('+', '', $digitsOnly);
+        $length = strlen($digitsForLength);
+
+        // Check length constraints
+        if ($length < self::MIN_LENGTH) {
+            return $this->failure(
+                sprintf(
+                    'Phone number "%s" is too short (minimum %d digits, got %d)',
+                    $value,
+                    self::MIN_LENGTH,
+                    $length
+                ),
+                [
+                    'value' => $value,
+                    'length' => $length,
+                    'min_length' => self::MIN_LENGTH,
+                    'constraint' => 'min_length'
+                ]
+            );
+        }
+
+        if ($length > self::MAX_LENGTH) {
+            return $this->failure(
+                sprintf(
+                    'Phone number "%s" is too long (maximum %d digits, got %d)',
+                    $value,
+                    self::MAX_LENGTH,
+                    $length
+                ),
+                [
+                    'value' => $value,
+                    'length' => $length,
+                    'max_length' => self::MAX_LENGTH,
+                    'constraint' => 'max_length'
+                ]
+            );
+        }
+
+        // Check for valid format patterns
+        $validPatterns = [
+            // E.164 format: +[country code][number]
+            '/^\+[1-9]\d{1,14}$/',
+            // With spaces: +1 234 567 890
+            '/^\+[1-9][\d\s]{1,18}$/',
+            // With dashes: +1-234-567-890
+            '/^\+[1-9][\d\-\s]{1,18}$/',
+            // With parentheses: +1 (234) 567-890
+            '/^\+?[1-9]?[\d\s\(\)\-]{6,20}$/',
+            // Local format without country code
+            '/^[\d\s\(\)\-]{7,20}$/',
+        ];
+
+        $matchesPattern = false;
+        foreach ($validPatterns as $pattern) {
+            if (preg_match($pattern, $value)) {
+                $matchesPattern = true;
+                break;
+            }
+        }
+
+        if (!$matchesPattern) {
+            return $this->failure(
+                sprintf('Phone number "%s" does not match valid format patterns', $value),
+                ['value' => $value, 'digits' => $digitsOnly]
+            );
+        }
+
+        // Success
+        return $this->success(
+            sprintf('Phone number "%s" is valid', $value),
+            [
+                'value' => $value,
+                'normalized' => $digitsOnly,
+                'length' => $length,
+                'has_country_code' => str_starts_with($digitsOnly, '+')
+            ]
+        );
+    }
+}

--- a/src/Validators/UuidValidator.php
+++ b/src/Validators/UuidValidator.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingyValidator\Validators;
+
+use ThingyValidator\ParameterizedValidator;
+use ThingyValidator\ValidationContext;
+use ThingyValidator\ValidationResult;
+
+/**
+ * Validates Universally Unique Identifiers (UUID)
+ *
+ * Validates UUID format according to RFC 4122 standard.
+ * Supports versions 1, 3, 4, and 5 with configurable version checking.
+ *
+ * UUID format: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
+ * - M = version (1, 3, 4, or 5)
+ * - N = variant (8, 9, A, or B for RFC 4122)
+ *
+ * Usage:
+ * ```php
+ * // Validate any UUID version
+ * $validator = new UuidValidator();
+ * $result = $validator->validate('550e8400-e29b-41d4-a716-446655440000'); // Valid v4
+ *
+ * // Validate specific version
+ * $validator = new UuidValidator(['version' => 4]);
+ * $result = $validator->validate('550e8400-e29b-41d4-a716-446655440000'); // Valid v4
+ * $result = $validator->validate('6ba7b810-9dad-11d1-80b4-00c04fd430c8'); // Invalid (v1)
+ * ```
+ *
+ * @package ThingyValidator\Validators
+ */
+class UuidValidator extends ParameterizedValidator
+{
+    /**
+     * Valid UUID versions
+     */
+    private const VALID_VERSIONS = [1, 3, 4, 5];
+
+    /**
+     * Create a new UUID validator
+     *
+     * @param array<string, mixed> $parameters Optional parameters:
+     *   - 'version' (int): Specific UUID version to validate (1, 3, 4, or 5)
+     */
+    public function __construct(array $parameters = [])
+    {
+        parent::__construct('uuid', $parameters);
+        $this->errorMessage = 'Invalid UUID format';
+        $this->successMessage = 'Valid UUID';
+    }
+
+    /**
+     * Perform UUID validation
+     *
+     * @param mixed $value The value to validate
+     * @param ValidationContext|null $context Optional validation context
+     * @return ValidationResult The validation result
+     */
+    protected function doValidate(mixed $value, ?ValidationContext $context): ValidationResult
+    {
+        // Must be a string
+        if (!is_string($value)) {
+            return $this->failure(
+                sprintf('UUID must be a string, %s given', gettype($value)),
+                ['type' => gettype($value)]
+            );
+        }
+
+        // Trim and convert to lowercase
+        $uuid = strtolower(trim($value));
+
+        // Cannot be empty
+        if ($uuid === '') {
+            return $this->failure(
+                'UUID cannot be empty',
+                ['value' => $value]
+            );
+        }
+
+        // Basic format check: 8-4-4-4-12 hexadecimal pattern
+        $pattern = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/';
+        if (!preg_match($pattern, $uuid)) {
+            return $this->failure(
+                sprintf('UUID "%s" does not match the standard format', $value),
+                ['value' => $value, 'expected_format' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx']
+            );
+        }
+
+        // Extract version (13th character, after 8+1+4+1)
+        $versionChar = $uuid[14]; // Position 14 (0-indexed)
+        $version = (int) $versionChar;
+
+        // Validate version is supported
+        if (!in_array($version, self::VALID_VERSIONS, true)) {
+            return $this->failure(
+                sprintf('UUID "%s" has invalid version %d (must be 1, 3, 4, or 5)', $value, $version),
+                ['value' => $value, 'version' => $version, 'constraint' => 'version']
+            );
+        }
+
+        // Extract variant (19th character, after 8+1+4+1+4+1)
+        $variantChar = $uuid[19]; // Position 19 (0-indexed)
+
+        // Validate variant is RFC 4122 compliant (8, 9, a, or b)
+        if (!in_array($variantChar, ['8', '9', 'a', 'b'], true)) {
+            return $this->failure(
+                sprintf('UUID "%s" has invalid variant "%s" (must be 8, 9, A, or B)', $value, $variantChar),
+                ['value' => $value, 'variant' => $variantChar, 'constraint' => 'variant']
+            );
+        }
+
+        // Check if specific version is required
+        $requiredVersion = $this->getParameterFromContext('version', $context);
+        if ($requiredVersion !== null) {
+            if (!in_array($requiredVersion, self::VALID_VERSIONS, true)) {
+                return $this->failure(
+                    sprintf('Invalid version parameter %d (must be 1, 3, 4, or 5)', $requiredVersion),
+                    ['required_version' => $requiredVersion]
+                );
+            }
+
+            if ($version !== $requiredVersion) {
+                return $this->failure(
+                    sprintf(
+                        'UUID "%s" is version %d, but version %d is required',
+                        $value,
+                        $version,
+                        $requiredVersion
+                    ),
+                    [
+                        'value' => $value,
+                        'actual_version' => $version,
+                        'required_version' => $requiredVersion,
+                        'constraint' => 'version_mismatch'
+                    ]
+                );
+            }
+        }
+
+        // Success
+        $message = sprintf('UUID "%s" is valid (version %d)', $value, $version);
+
+        return $this->success($message, [
+            'value' => $value,
+            'normalized' => $uuid,
+            'version' => $version,
+            'variant' => $variantChar,
+        ]);
+    }
+}


### PR DESCRIPTION
Adds three comprehensive format validators with industry-standard validation:

**PhoneValidator**
- Validates international phone numbers (E.164 and common formats)
- Supports country codes, multiple separator styles
- Length validation (7-15 digits per E.164 standard)
- Handles: +1234567890, +1 (234) 567-890, (234) 567-890
- Detailed error messages for format violations

**IbanValidator**
- Validates International Bank Account Numbers (ISO 13616)
- Country-specific length validation for 70+ countries
- MOD-97 checksum algorithm verification
- Handles all SEPA and major international formats
- Validates: country code, check digits, length, checksum

**UuidValidator (ParameterizedValidator)**
- Validates UUIDs according to RFC 4122
- Supports versions 1, 3, 4, and 5
- Optional version-specific validation
- Validates: format, version, variant (RFC 4122 compliance)
- Parameter: 'version' for strict version checking

All validators:
- Comprehensive PHPDoc with usage examples
- Detailed error messages with constraint information
- Type-safe with strict typing
- Zero external dependencies
- Pure PHP implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)